### PR TITLE
Switch to assertj assertions from junit

### DIFF
--- a/leaflet-core/pom.xml
+++ b/leaflet-core/pom.xml
@@ -52,6 +52,12 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/leaflet-core/src/test/java/sk/drunkenpanda/leaflet/DefaultLeafletSettingsTest.java
+++ b/leaflet-core/src/test/java/sk/drunkenpanda/leaflet/DefaultLeafletSettingsTest.java
@@ -16,14 +16,14 @@
 
 package sk.drunkenpanda.leaflet;
 
-import sk.drunkenpanda.leaflet.resources.LeafletJavascriptResourceReference;
-import sk.drunkenpanda.leaflet.resources.LeafletStylesheetResourceReference;
 import org.apache.wicket.request.resource.CssResourceReference;
 import org.apache.wicket.request.resource.JavaScriptResourceReference;
 import org.apache.wicket.request.resource.ResourceReference;
 import org.apache.wicket.request.resource.UrlResourceReference;
-import org.junit.Assert;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
+import sk.drunkenpanda.leaflet.resources.LeafletJavascriptResourceReference;
+import sk.drunkenpanda.leaflet.resources.LeafletStylesheetResourceReference;
 
 /**
  *
@@ -35,53 +35,53 @@ public class DefaultLeafletSettingsTest extends AbstractLeafletTest {
     @Test
     public void testGetWebJarJavascriptReferenceByDefault() {
         ResourceReference reference = new DefaultLeafletSettings().getJavascriptReference();
-        Assert.assertTrue(reference.getClass().isAssignableFrom(LeafletJavascriptResourceReference.class));
+        assertThat(reference.getClass().isAssignableFrom(LeafletJavascriptResourceReference.class)).isTrue();
     }
-    
+
     @Test
     public void testGetCDNJavascriptReferenceIfCDNRequested() {
         ResourceReference reference = new DefaultLeafletSettings.Builder()
                 .setUseCdn(true).build().getJavascriptReference();
-        Assert.assertTrue(reference.getClass().isAssignableFrom(UrlResourceReference.class));
+        assertThat(reference.getClass().isAssignableFrom(UrlResourceReference.class)).isTrue();
     }
-    
+
     @Test
     public void testGetLocalJavascriptResourceReferenceIfSet() {
         JavaScriptResourceReference expected = new JavaScriptResourceReference(getClass(), "leaflet.js");
         ResourceReference reference = new DefaultLeafletSettings.Builder()
                 .setJavascriptReference(expected)
                 .build().getJavascriptReference();
-        Assert.assertEquals(expected, reference);
+        assertThat(reference).isEqualTo(expected);
     }
-    
+
     @Test
     public void testGetWebJarCSSReferenceByDefault() {
         ResourceReference reference = new DefaultLeafletSettings().getCssReference();
-        Assert.assertTrue(reference.getClass().isAssignableFrom(LeafletStylesheetResourceReference.class));        
+        assertThat(reference.getClass().isAssignableFrom(LeafletStylesheetResourceReference.class)).isTrue();
     }
-    
+
     @Test
     public void testGetCDNStylesheetReferenceIfCDNRequested() {
         ResourceReference reference = new DefaultLeafletSettings.Builder()
                 .setUseCdn(true).build().getCssReference();
-        Assert.assertTrue(reference.getClass().isAssignableFrom(UrlResourceReference.class));
+        assertThat(reference.getClass().isAssignableFrom(UrlResourceReference.class)).isTrue();
     }
-    
+
     @Test
     public void testGetLocalCSSResourceReferenceIfSet() {
         CssResourceReference expected = new CssResourceReference(getClass(), "leaflet.css");
         ResourceReference reference = new DefaultLeafletSettings.Builder().setCssReference(expected)
                 .build().getCssReference();
-        Assert.assertEquals(expected, reference);
+        assertThat(reference).isEqualTo(expected);
     }
-    
+
     @Test
     public void testDoesntUseWebJarsIfCDNIsSet() {
         DefaultLeafletSettings settings = new DefaultLeafletSettings.Builder()
                 .setUseCdn(true).build();
-        Assert.assertFalse(settings.useWebJars());
+        assertThat(settings.useWebJars()).isFalse();
     }
-    
+
     @Test
     public void testDoesntUseWebJarsIfReferencesAreSet() {
         CssResourceReference cssReference = new CssResourceReference(getClass(), "leaflet.css");
@@ -89,12 +89,12 @@ public class DefaultLeafletSettingsTest extends AbstractLeafletTest {
         DefaultLeafletSettings settings = new DefaultLeafletSettings.Builder()
                 .setCssReference(cssReference)
                 .setJavascriptReference(jsReference).build();
-        Assert.assertFalse(settings.useWebJars());
+        assertThat(settings.useWebJars()).isFalse();
     }
-        
+
     @Test
     public void testUsesWebJarsByDefault() {
         DefaultLeafletSettings settings = new DefaultLeafletSettings();
-        Assert.assertTrue(settings.useWebJars());
+        assertThat(settings.useWebJars()).isTrue();
     }
 }

--- a/leaflet-core/src/test/java/sk/drunkenpanda/leaflet/LeafletTest.java
+++ b/leaflet-core/src/test/java/sk/drunkenpanda/leaflet/LeafletTest.java
@@ -17,24 +17,22 @@
 package sk.drunkenpanda.leaflet;
 
 import org.apache.wicket.Page;
-import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.mock.MockHomePage;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.util.tester.TagTester;
 import org.apache.wicket.util.tester.WicketTester;
-import org.junit.Assert;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Before;
 import org.junit.Test;
-import sk.drunkenpanda.leaflet.resources.LeafletStylesheetResourceReference;
 
 /**
  *
- * @author Jan Ferko 
+ * @author Jan Ferko
  */
 public class LeafletTest {
-    
+
     private LeafletSettings customSettings;
-    
+
     @Before
     public void before() {
         customSettings = new DefaultLeafletSettings.Builder()
@@ -43,130 +41,130 @@ public class LeafletTest {
             .setVersion("0.1")
             .build();
     }
-    
+
     @Test(expected = IllegalArgumentException.class)
     public void testInstallWithNullApp() {
         Leaflet.install(null);
     }
-    
-    @Test
-    public void testDefaultConfigurationWasInstalled() {        
-        WicketTester tester = new WicketTester(createWebApp(null, true));
-        LeafletSettings settings = tester.getApplication().getMetaData(Leaflet.LEAFLET_SETTINGS_KEY);
-        
-        compareSettings(new DefaultLeafletSettings(), settings);
-    }        
 
     @Test
-    public void testCustomConfigurationWasInstalled() {        
+    public void testDefaultConfigurationWasInstalled() {
+        WicketTester tester = new WicketTester(createWebApp(null, true));
+        LeafletSettings settings = tester.getApplication().getMetaData(Leaflet.LEAFLET_SETTINGS_KEY);
+
+        compareSettings(new DefaultLeafletSettings(), settings);
+    }
+
+    @Test
+    public void testCustomConfigurationWasInstalled() {
         WicketTester tester = new WicketTester(createWebApp(customSettings, true));
-        
+
         LeafletSettings actual = tester.getApplication().getMetaData(Leaflet.LEAFLET_SETTINGS_KEY);
         compareSettings(customSettings, actual);
     }
-    
-    @Test(expected = IllegalArgumentException.class) 
+
+    @Test(expected = IllegalArgumentException.class)
     public void testInstallCustomConfigurationToNullApp() {
         Leaflet.install(null, new DefaultLeafletSettings());
     }
-    
+
     @Test
     public void testDoesntInstallIfLeafletsAreAlreadyInstalled() {
-        WicketTester tester = new WicketTester(createWebApp(customSettings, true));        
+        WicketTester tester = new WicketTester(createWebApp(customSettings, true));
         Leaflet.install(tester.getApplication());
         LeafletSettings actual = tester.getApplication().getMetaData(Leaflet.LEAFLET_SETTINGS_KEY);
         compareSettings(customSettings, actual);
-    }        
-    
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testGetSettingsForNullApplication() {
         Leaflet.getSettings(null);
     }
-    
+
     @Test(expected = IllegalStateException.class)
     public void testGetSettingWithoutInstallation() {
         // application.init wasn't called yet
         WebApplication application = createWebApp(null, false);
         Leaflet.getSettings(application);
     }
-    
+
     @Test
     public void testGetSettingsForApplication() {
         WicketTester tester = new WicketTester(createWebApp(customSettings, true));
         LeafletSettings settings = Leaflet.getSettings(tester.getApplication());
         compareSettings(customSettings, settings);
     }
-    
+
     @Test
     public void testGetSettingsForThreadLocalApplication() {
         WicketTester tester = new WicketTester(createWebApp(customSettings, true));
         LeafletSettings settings = Leaflet.getSettings();
-        compareSettings(customSettings, settings);        
+        compareSettings(customSettings, settings);
     }
-    
+
     @Test(expected = IllegalStateException.class)
     public void testGetSettingsForThreadLocalApplicationWithoutInstallation() {
         WicketTester tester = new WicketTester(createWebApp(null, false));
         LeafletSettings settings = Leaflet.getSettings();
     }
-    
-    //@TODO webjar resources init   
-    
+
+    //@TODO webjar resources init
+
     @Test
     public void testAddResourcesIfAutoAppendIsUsed() {
         WicketTester tester = new WicketTester(createWebApp(customSettings, true));
         tester.startPage(MockHomePage.class);
-        
-        TagTester jsResource = TagTester.createTagByAttribute(tester.getLastResponseAsString(), "src", 
+
+        TagTester jsResource = TagTester.createTagByAttribute(tester.getLastResponseAsString(), "src",
                 String.format(DefaultLeafletSettings.JS_CDN_PATTERN, customSettings.getVersion()));
-        Assert.assertNotNull(jsResource);
-        Assert.assertEquals("script", jsResource.getName());
-        
+        assertThat(jsResource).isNotNull();
+        assertThat(jsResource.getName()).isEqualTo("script");
+
         TagTester cssResource = TagTester.createTagByAttribute(tester.getLastResponseAsString(), "href",
                 String.format(DefaultLeafletSettings.CSS_CDN_PATTERN, customSettings.getVersion()));
-        Assert.assertNotNull(cssResource);
-        Assert.assertEquals("link", cssResource.getName());
+        assertThat(cssResource).isNotNull();
+        assertThat(cssResource.getName()).isEqualTo("link");
     }
-    
+
     @Test
     public void testDontAddResourceIfAutoAppendIsntUsed() {
         DefaultLeafletSettings settings = new DefaultLeafletSettings();
         WicketTester tester = new WicketTester(createWebApp(settings, true));
         tester.startPage(MockHomePage.class);
-        
+
         tester.assertContainsNot("<script>");
         tester.assertContainsNot("<link>");
     }
-    
+
     private void compareSettings(LeafletSettings expected, LeafletSettings actual) {
-        Assert.assertNotNull(actual);
-        Assert.assertEquals(expected.getCssReference(), actual.getCssReference());
-        Assert.assertEquals(expected.getJavascriptReference(), actual.getJavascriptReference());
-        Assert.assertEquals(expected.getVersion(), actual.getVersion());
-        Assert.assertEquals(expected.useCDN(), actual.useCDN());
-        Assert.assertEquals(expected.useWebJars(), actual.useWebJars());
+        assertThat(actual).isNotNull();
+        assertThat(actual.getCssReference()).isEqualTo(expected.getCssReference());
+        assertThat(actual.getJavascriptReference()).isEqualTo(expected.getJavascriptReference());
+        assertThat(actual.getVersion()).isEqualTo(expected.getVersion());
+        assertThat(actual.useCDN()).isEqualTo(expected.useCDN());
+        assertThat(actual.useWebJars()).isEqualTo(expected.useWebJars());
     }
-    
+
     private WebApplication createWebApp(final LeafletSettings settings, final boolean installLeaflets) {
         return new WebApplication() {
 
             @Override
             protected void init() {
-                super.init();                                
+                super.init();
                 if (installLeaflets) {
                     if (settings == null) {
                         Leaflet.install(this);
                     } else {
                         Leaflet.install(this, settings);
-                    }                    
+                    }
                 }
             }
 
             @Override
             public Class<? extends Page> getHomePage() {
                 return Page.class;
-            }            
+            }
         };
-    }        
-        
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <servlet.version>2.5</servlet.version>
     <junit.version>4.11</junit.version>
     <mockito.version>1.9.5</mockito.version>
+    <assertj.version>1.7.1</assertj.version>
 
     <jacoco.version>0.7.5.201505241946</jacoco.version>
     <coveralls.version>3.1.0</coveralls.version>
@@ -125,6 +126,13 @@
         <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+          <groupId>org.assertj</groupId>
+          <artifactId>assertj-core</artifactId>
+          <version>${assertj.version}</version>
+          <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Switch default assertions in unit test to [AssertJ](https://joel-costigliola.github.io/assertj/). AssertJ provides more fluent assertions with better failure messages.