### PR TITLE
Upgrade wicket libraries

### DIFF
--- a/leaflet-core/pom.xml
+++ b/leaflet-core/pom.xml
@@ -51,7 +51,7 @@
 
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,12 +48,12 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>23.0-android</guava.version>
-    <wicket.version>6.18.0</wicket.version>
-    <webjars.version>0.4.12</webjars.version>
+    <wicket.version>7.8.0</wicket.version>
+    <webjars.version>0.5.6</webjars.version>
     <leaflet.version>0.7.3</leaflet.version>
     <log4j.version>1.2.16</log4j.version>
     <slf4j.version>1.6.4</slf4j.version>
-    <servlet.version>2.5</servlet.version>
+    <servlet.version>3.0.1</servlet.version>
     <jackson.version>2.5.4</jackson.version>
     <junit.version>4.12</junit.version>
     <mockito.version>1.9.5</mockito.version>
@@ -62,8 +62,8 @@
 
     <jacoco.version>0.7.5.201505241946</jacoco.version>
 
-    <maven.java.source>1.6</maven.java.source>
-    <maven.java.target>1.6</maven.java.target>
+    <maven.java.source>1.7</maven.java.source>
+    <maven.java.target>1.7</maven.java.target>
   </properties>
 
   <repositories>
@@ -113,7 +113,7 @@
 
       <dependency>
         <groupId>javax.servlet</groupId>
-        <artifactId>servlet-api</artifactId>
+        <artifactId>javax.servlet-api</artifactId>
         <version>${servlet.version}</version>
       </dependency>
 


### PR DESCRIPTION
New version requires at least JDK 7.

Updated versions:
* Wicket - 7.8.0
* Wicket-Webjars - 0.5.6
* servlet-api - 3.1.0